### PR TITLE
Use NewObject in network manager constructor

### DIFF
--- a/Source/PlanetSystem/Private/Network/PlanetSystemNetworkManager.cpp
+++ b/Source/PlanetSystem/Private/Network/PlanetSystemNetworkManager.cpp
@@ -13,8 +13,17 @@
 UPlanetSystemNetworkManager::UPlanetSystemNetworkManager()
 {
     // Inicializar componentes
-    ChunkCache = CreateDefaultSubobject<UPlanetChunkNetworkCache>(TEXT("ChunkCache"));
-    NetworkEventBus = CreateDefaultSubobject<UPlanetNetworkEventBus>(TEXT("NetworkEventBus"));
+    ChunkCache = NewObject<UPlanetChunkNetworkCache>(this, UPlanetChunkNetworkCache::StaticClass(), TEXT("ChunkCache"));
+    if (ChunkCache)
+    {
+        ChunkCache->AddToRoot();
+    }
+
+    NetworkEventBus = NewObject<UPlanetNetworkEventBus>(this, UPlanetNetworkEventBus::StaticClass(), TEXT("NetworkEventBus"));
+    if (NetworkEventBus)
+    {
+        NetworkEventBus->AddToRoot();
+    }
     
     // Obter serviços do ServiceLocator
     Logger = UPlanetSystemLogger::GetInstance();


### PR DESCRIPTION
## Summary
- replace deprecated `CreateDefaultSubobject` calls in `UPlanetSystemNetworkManager` with `NewObject`
- keep created objects alive using `AddToRoot`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b8ff628048325b1beb8a70516563a