### PR TITLE
Implement missing log helper methods

### DIFF
--- a/Source/PlanetSystem/Private/Debug/Logging/PlanetSystemLogger.cpp
+++ b/Source/PlanetSystem/Private/Debug/Logging/PlanetSystemLogger.cpp
@@ -166,6 +166,24 @@ void UPlanetSystemLogger::LogDebug(const FString& Message, const FString& Contex
     Log(FullMessage, EPlanetLogLevel::Debug, Category);
 }
 
+void UPlanetSystemLogger::LogInfo(const FString& Message, const FString& Context, EPlanetLogCategory Category)
+{
+    FString FullMessage = Context.IsEmpty() ? Message : FString::Printf(TEXT("%s (Context: %s)"), *Message, *Context);
+    Log(FullMessage, EPlanetLogLevel::Info, Category);
+}
+
+void UPlanetSystemLogger::LogVerbose(const FString& Message, const FString& Context, EPlanetLogCategory Category)
+{
+    FString FullMessage = Context.IsEmpty() ? Message : FString::Printf(TEXT("%s (Context: %s)"), *Message, *Context);
+    Log(FullMessage, EPlanetLogLevel::Verbose, Category);
+}
+
+void UPlanetSystemLogger::LogCritical(const FString& Message, const FString& Context, EPlanetLogCategory Category)
+{
+    FString FullMessage = Context.IsEmpty() ? Message : FString::Printf(TEXT("%s (Context: %s)"), *Message, *Context);
+    Log(FullMessage, EPlanetLogLevel::Critical, Category);
+}
+
 void UPlanetSystemLogger::LogEvent(const FString& EventName, const FString& Details, EPlanetLogCategory Category)
 {
     FString Message = Details.IsEmpty() ? EventName : FString::Printf(TEXT("%s: %s"), *EventName, *Details);

--- a/Source/PlanetSystem/Public/Debug/Logging/PlanetSystemLogger.h
+++ b/Source/PlanetSystem/Public/Debug/Logging/PlanetSystemLogger.h
@@ -132,8 +132,23 @@ public:
     
     /** Log de debug com contexto */
     UFUNCTION(BlueprintCallable, Category="Logging")
-    static void LogDebug(const FString& Message, const FString& Context = TEXT(""), 
+    static void LogDebug(const FString& Message, const FString& Context = TEXT(""),
                         EPlanetLogCategory Category = EPlanetLogCategory::General);
+
+    /** Log de informação com contexto */
+    UFUNCTION(BlueprintCallable, Category="Logging")
+    static void LogInfo(const FString& Message, const FString& Context = TEXT(""),
+                        EPlanetLogCategory Category = EPlanetLogCategory::General);
+
+    /** Log detalhado (verbose) com contexto */
+    UFUNCTION(BlueprintCallable, Category="Logging")
+    static void LogVerbose(const FString& Message, const FString& Context = TEXT(""),
+                           EPlanetLogCategory Category = EPlanetLogCategory::General);
+
+    /** Log crítico com contexto */
+    UFUNCTION(BlueprintCallable, Category="Logging")
+    static void LogCritical(const FString& Message, const FString& Context = TEXT(""),
+                            EPlanetLogCategory Category = EPlanetLogCategory::General);
     
     /** Log de evento do sistema */
     UFUNCTION(BlueprintCallable, Category="Logging")


### PR DESCRIPTION
## Summary
- expose new logging helpers for info, verbose, and critical levels
- implement helper methods in PlanetSystemLogger

## Testing
- `clang++ --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ba9fd870c8325913d8a775094e906