### PR TITLE
Add ValidateCoreConfig wrapper

### DIFF
--- a/Source/PlanetSystem/Private/Configuration/Validators/PlanetConfigValidator.cpp
+++ b/Source/PlanetSystem/Private/Configuration/Validators/PlanetConfigValidator.cpp
@@ -86,6 +86,12 @@ bool UPlanetConfigValidator::ValidateConfig(const UPlanetCoreConfig* Config, TAr
     }
 }
 
+bool UPlanetConfigValidator::ValidateCoreConfig(const UPlanetCoreConfig* Config, TArray<FPlanetValidationError>& OutErrors)
+{
+    // Mantido para compatibilidade com chamadas existentes
+    return ValidateConfig(Config, OutErrors);
+}
+
 bool UPlanetConfigValidator::ValidateGenerationConfig(const FPlanetGenerationConfig& Config, TArray<FPlanetValidationError>& OutErrors)
 {
     try

--- a/Source/PlanetSystem/Public/Configuration/Validators/PlanetConfigValidator.h
+++ b/Source/PlanetSystem/Public/Configuration/Validators/PlanetConfigValidator.h
@@ -105,10 +105,14 @@ class PLANETSYSTEM_API UPlanetConfigValidator : public UObject
     
 public:
     UPlanetConfigValidator();
-    
+
     /** Valida a configuração completa do planeta */
     UFUNCTION(BlueprintCallable, Category="Validation")
     static bool ValidateConfig(const UPlanetCoreConfig* Config, TArray<FPlanetValidationError>& OutErrors);
+
+    /** Valida a configuração principal do planeta (alias de ValidateConfig) */
+    UFUNCTION(BlueprintCallable, Category="Validation")
+    static bool ValidateCoreConfig(const UPlanetCoreConfig* Config, TArray<FPlanetValidationError>& OutErrors);
     
     /** Valida apenas a configuração de geração */
     UFUNCTION(BlueprintCallable, Category="Validation")


### PR DESCRIPTION
## Summary
- expose `ValidateCoreConfig` in the validator API
- implement wrapper around `ValidateConfig`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ba9fe5bd48325bb3aed43cdbf1d43