### PR TITLE
Fix event bus parameter usage

### DIFF
--- a/Source/PlanetSystem/Private/Core/Events/PlanetEventBus.cpp
+++ b/Source/PlanetSystem/Private/Core/Events/PlanetEventBus.cpp
@@ -123,7 +123,7 @@ void UPlanetEventBus::BroadcastEventWithParams(EPlanetEventType EventType, const
     Event.StringParam = StringParam;
     Event.FloatParam = FloatParam;
     Event.IntParam = IntParam;
-    Event.UniqueID = FGuid::NewGuid();
+    Event.EventID = FGuid::NewGuid();
     Event.SourceModule = TEXT("PlanetEventBus");
     
     BroadcastEvent(Event);

--- a/Source/PlanetSystem/Private/Services/Core/ServiceLocator.cpp
+++ b/Source/PlanetSystem/Private/Services/Core/ServiceLocator.cpp
@@ -290,9 +290,9 @@ void UPlanetSystemServiceLocator::BroadcastEventWithParams(EPlanetEventType Even
     FPlanetSystemEvent Event;
     Event.EventType = EventType;
     Event.CustomName = CustomName;
-    Event.StringParameter = StringParam;
-    Event.FloatParameter = FloatParam;
-    Event.IntParameter = IntParam;
+    Event.StringParam = StringParam;
+    Event.FloatParam = FloatParam;
+    Event.IntParam = IntParam;
     Event.Timestamp = FPlatformTime::Seconds();
     Event.SourceModule = TEXT("ServiceLocator");
     

--- a/Source/PlanetSystem/Public/Core/Events/PlanetSystemEvents.h
+++ b/Source/PlanetSystem/Public/Core/Events/PlanetSystemEvents.h
@@ -38,7 +38,7 @@ struct PLANETSYSTEM_API FPlanetSystemEvent
     
     /** Nome customizado do evento (usado quando EventType é Custom) */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Event")
-    FString CustomEventName;
+    FString CustomName;
     
     /** Timestamp do evento */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Event")
@@ -51,6 +51,18 @@ struct PLANETSYSTEM_API FPlanetSystemEvent
     /** Parâmetros do evento */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Event")
     TMap<FString, FString> Parameters;
+
+    /** Parâmetro string rápido */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Event")
+    FString StringParam = TEXT("");
+
+    /** Parâmetro float rápido */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Event")
+    float FloatParam = 0.0f;
+
+    /** Parâmetro inteiro rápido */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Event")
+    int32 IntParam = 0;
     
     /** Dados binários do evento (para dados complexos) */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Event")
@@ -69,6 +81,9 @@ struct PLANETSYSTEM_API FPlanetSystemEvent
         Timestamp = FDateTime::Now();
         EventID = FGuid::NewGuid();
         Priority = 5;
+        StringParam = TEXT("");
+        FloatParam = 0.0f;
+        IntParam = 0;
     }
     
     /**
@@ -143,7 +158,7 @@ struct PLANETSYSTEM_API FPlanetSystemEvent
     {
         if (EventType == EPlanetEventType::Custom)
         {
-            return CustomEventName;
+            return CustomName;
         }
         
         static const UEnum* EventTypeEnum = FindObject<UEnum>(nullptr, TEXT("/Script/PlanetSystem.EPlanetEventType"));


### PR DESCRIPTION
## Summary
- add missing quick parameter fields in `FPlanetSystemEvent`
- use new fields when broadcasting events
- update service locator to use unified parameter names

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ba9fce4a08325ad56c8e09f80064f