### PR TITLE
Fix validation error logging message property

### DIFF
--- a/Source/PlanetSystem/Private/Services/Core/ServiceLocator.cpp
+++ b/Source/PlanetSystem/Private/Services/Core/ServiceLocator.cpp
@@ -51,7 +51,7 @@ void UPlanetSystemServiceLocator::InitializeServices(UPlanetCoreConfig* Config)
         for (const FPlanetValidationError& Error : ValidationErrors)
         {
             UPlanetSystemLogger::LogWarning(TEXT("ServiceLocator"), 
-                FString::Printf(TEXT("Validation Error: %s - %s"), *Error.FieldName, *Error.Message));
+                FString::Printf(TEXT("Validation Error: %s - %s"), *Error.FieldName, *Error.ErrorMessage));
         }
         
         // Apply auto-fixes if possible


### PR DESCRIPTION
## Summary
- correct FPlanetValidationError member name when logging validation errors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bade315a08325bade553d00325aad